### PR TITLE
fix(ci): skip commit and push when README unchanged

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -12,10 +12,14 @@ jobs:
       - uses: actions/checkout@v3
       - uses: oven-sh/setup-bun@v2
       - run: bun run generate
-      - name: Commit
+      - name: Commit and push if changed
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git add -A
-          git diff --quiet && git diff --staged --quiet || git commit -m "./generate > README.md"
-          git push
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "./generate > README.md"
+            git push
+          fi


### PR DESCRIPTION
Refactored the commit step to only push when there are actual changes, avoiding unnecessary git operations on scheduled runs.