### PR TITLE
fix: use realistic symlink permissions and improve error handling

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
-          git add -A
+          git add README.md
           if git diff --staged --quiet; then
             echo "No changes to commit"
           else

--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
 <pre>
 jacksonblankenship@github ~> ls -lt | sed 1d | head -n 10 | sort -k9,9
-
 drwxr-xr-x@  2  jacksonblankenship    4.0M  Jan 25  <a href="https://github.com/jacksonblankenship/jacksonblankenship">jacksonblankenship</a>
-lrwxr-xr-x@  1  jacksonblankenship    336K  Nov 01  <a href="https://github.com/jacksonblankenship/nestjs-drizzle">nestjs-drizzle</a> -> <a href="https://github.com/MMADUs/NestJS-Drizzle">MMADUs/NestJS-Drizzle</a>
+lrwxrwxrwx@  1  jacksonblankenship    336K  Nov 01  <a href="https://github.com/jacksonblankenship/nestjs-drizzle">nestjs-drizzle</a> -> <a href="https://github.com/MMADUs/NestJS-Drizzle">MMADUs/NestJS-Drizzle</a>
 drwxr-xr-x@  2  jacksonblankenship    491K  Apr 06  <a href="https://github.com/jacksonblankenship/node-starter">node-starter</a>
 drwxr-xr-x@  2  jacksonblankenship    3.3M  Jan 23  <a href="https://github.com/jacksonblankenship/pickem">pickem</a>
 drwxr-xr-x@  2  jacksonblankenship    660K  Jan 25  <a href="https://github.com/jacksonblankenship/pickem-be">pickem-be</a>
 drwxr-xr-x@  2  jacksonblankenship    286K  Sep 18  <a href="https://github.com/jacksonblankenship/roombarr">roombarr</a>
-lrwxr-xr-x@  1  jacksonblankenship    1.5M  Feb 21  <a href="https://github.com/jacksonblankenship/t3-env">t3-env</a> -> <a href="https://github.com/t3-oss/t3-env">t3-oss/t3-env</a>
-lrwxr-xr-x@  1  jacksonblankenship   10.9M  Jan 18  <a href="https://github.com/jacksonblankenship/testing-nestjs">testing-nestjs</a> -> <a href="https://github.com/jmcdo29/testing-nestjs">jmcdo29/testing-nestjs</a>
-lrwxr-xr-x@  1  jacksonblankenship   22.4M  Jan 25  <a href="https://github.com/jacksonblankenship/vscode-icons">vscode-icons</a> -> <a href="https://github.com/vscode-icons/vscode-icons">vscode-icons/vscode-icons</a>
-lrwxr-xr-x@  1  jacksonblankenship   18.2M  Apr 11  <a href="https://github.com/jacksonblankenship/zod">zod</a> -> <a href="https://github.com/colinhacks/zod">colinhacks/zod</a>
+lrwxrwxrwx@  1  jacksonblankenship    1.5M  Feb 21  <a href="https://github.com/jacksonblankenship/t3-env">t3-env</a> -> <a href="https://github.com/t3-oss/t3-env">t3-oss/t3-env</a>
+lrwxrwxrwx@  1  jacksonblankenship   10.9M  Jan 18  <a href="https://github.com/jacksonblankenship/testing-nestjs">testing-nestjs</a> -> <a href="https://github.com/jmcdo29/testing-nestjs">jmcdo29/testing-nestjs</a>
+lrwxrwxrwx@  1  jacksonblankenship   22.4M  Jan 25  <a href="https://github.com/jacksonblankenship/vscode-icons">vscode-icons</a> -> <a href="https://github.com/vscode-icons/vscode-icons">vscode-icons/vscode-icons</a>
+lrwxrwxrwx@  1  jacksonblankenship   18.2M  Apr 11  <a href="https://github.com/jacksonblankenship/zod">zod</a> -> <a href="https://github.com/colinhacks/zod">colinhacks/zod</a>
 </pre>
 <!-- designed by jacksonblankenship <https://github.com/jacksonblankenship> -->


### PR DESCRIPTION
- Change symlink permissions to lrwxrwxrwx (symlinks always have full perms)
- Add error handling for GitHub API requests
- Rename variables to SCREAMING_CASE constants
- Only stage README.md in CI to avoid accidental commits